### PR TITLE
(maint) update spoligotype_wrapper.sh

### DIFF
--- a/bin/spoligotype_wrapper.sh
+++ b/bin/spoligotype_wrapper.sh
@@ -8,12 +8,12 @@ FILENAME="$1"
 SPDB="$2"
 
 if [ ! -f "$SPOLIGO" ]; then
-  cd "$DIR/spoligotype"
+  cd "$DIR/spoligotype" || exit
   g++ -std=c++0x spoligotype_info.cpp -o spoligotype_info
 fi
 
-if [ ${FILENAME: -3} == ".gz" ]; then
-  gunzip -c "$FILENAME" | $SPOLIGO /dev/stdin | $LOOKUP $2
+if [ "${FILENAME: -3}" == ".gz" ]; then
+  gunzip -c "$FILENAME" | $SPOLIGO /dev/stdin | $LOOKUP "$SPDB"
 else
-  $SPOLIGO $FILENAME | $LOOKUP $2
+  $SPOLIGO "$FILENAME" | $LOOKUP "$SPDB"
 fi


### PR DESCRIPTION
- Use defined `SPDB` variable, but had remained unused
- Add `OR` logic in case `cd` on line 11 fails
- Quote variables to avoid possible globbing/expansion