### PR TITLE
(fix) remove len() as a condition

### DIFF
--- a/apps/versioner/middleware.py
+++ b/apps/versioner/middleware.py
@@ -46,7 +46,7 @@ class VersionInformation(BaseMiddleware):
         for label, remote in BRANCHES:
             branch = self.get_iter(local, remote)
             branches.append((label, branch))
-            if len(branch):
+            if branch:
                 response.context_data['branch_updates'] = True
     
         response.context_data['branches'] = branches


### PR DESCRIPTION
An empty list will evaluate to False. No need to use `len()` here.