### PR TITLE
(maint) python clean up

### DIFF
--- a/R/Neural_Network/program/Helper.py
+++ b/R/Neural_Network/program/Helper.py
@@ -4,7 +4,7 @@
 # jimmy.royer@analysisgroup.com
 # May 29, 2016
 
-from sknn.mlp import Classifier, Layer, Native
+from sknn.mlp import Classifier, Layer
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 from sklearn.grid_search import GridSearchCV

--- a/R/Neural_Network/program/Neural_Network_ETH.py
+++ b/R/Neural_Network/program/Neural_Network_ETH.py
@@ -10,8 +10,6 @@
 import os
 import numpy as np
 import pickle
-import collections
-from sklearn.feature_selection import RFE
 
 
 # Change to Current Directory

--- a/apps/explore/models.py
+++ b/apps/explore/models.py
@@ -1,6 +1,5 @@
 from django.db import models
 from model_utils.models import TimeStampedModel
-from django.utils.text import slugify
 
 
 class ExploreDataFileInfo(TimeStampedModel):

--- a/apps/explore/tests.py
+++ b/apps/explore/tests.py
@@ -1,3 +1,1 @@
 from django.test import TestCase
-
-# Create your tests here.

--- a/apps/maps/management/commands/load_map_data.py
+++ b/apps/maps/management/commands/load_map_data.py
@@ -10,8 +10,7 @@ from zipfile import ZipFile, BadZipFile
 import requests
 
 from django.conf import settings
-from django.utils import six
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.contrib.gis.utils import LayerMapping
 
 from apps.maps.models import Country, CountryDetail, Place

--- a/apps/maps/migrations/0002_auto_20161214_1025.py
+++ b/apps/maps/migrations/0002_auto_20161214_1025.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-from ..gis import MultiPolygonField, MultiPointField
+from ..gis import MultiPolygonField
 
 
 class Migration(migrations.Migration):

--- a/apps/maps/migrations/0004_auto_20181107_1309.py
+++ b/apps/maps/migrations/0004_auto_20181107_1309.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterUniqueTogether(
             name='place',
-            unique_together=set([('name', 'country')]),
+            unique_together={('name', 'country')},
         ),
     ]

--- a/apps/maps/mixins.py
+++ b/apps/maps/mixins.py
@@ -46,7 +46,7 @@ class DjangoJSONEncoder2(DjangoJSONEncoder):
             return {'__type__': 'datetime.timedelta',
                     'args': [getattr(obj, arg) for arg in args]}
         if isinstance(obj, QuerySet):
-            return [item for item in obj]
+            return list(obj)
         return DjangoJSONEncoder.default(self, obj)
 
 #Inherit from the parent class View and add Caching
@@ -85,7 +85,7 @@ class JsonView(View):
         raise NotImplementedError("Please provide context data.")
 
 
-class DataSlicerMixin(object):
+class DataSlicerMixin():
     """
     Provide a way to slice up a given model based on inputs.
     """
@@ -139,7 +139,8 @@ class DataSlicerMixin(object):
             qset = qset.values(*vals)
         return qset
 
-    def get_list(self, qs, column, *cols):
+    @staticmethod
+    def get_list(qs, column, *cols):
         """Returns a flat list for this column"""
         if cols:
             qs = qs.values_list(column, *cols)
@@ -161,9 +162,9 @@ def as_set(val):
     """
     if val is None:
         return set()
-    return set(val) if isinstance(val, (tuple, list)) else set([val])
+    return set(val) if isinstance(val, (tuple, list)) else {val}
 
-class DataTableMixin(object):
+class DataTableMixin():
     """
     Return context rendered as a Json output for the DataTables plugin.
     """
@@ -210,7 +211,8 @@ class DataTableMixin(object):
         db_columns = [self.column_to_django(col) for col in columns]
         return [self.prep_item(item, db_columns, **extra) for item in qset] #.values(*db_columns)]
 
-    def prep_item(self, obj, columns, **extra):
+    @staticmethod
+    def prep_item(obj, columns, **extra):
         """
         Prepare this item for output using the requested columns.
         """
@@ -225,7 +227,8 @@ class DataTableMixin(object):
         ret.update(extra)
         return ret
 
-    def column_to_django(self, column, db=True):
+    @staticmethod
+    def column_to_django(column, db=True):
         """We calculate the column's django address,
 
         If db is True, then this must return the database field, if false

--- a/apps/maps/views.py
+++ b/apps/maps/views.py
@@ -26,15 +26,14 @@ from collections import defaultdict, OrderedDict
 from django.views.generic import TemplateView, ListView
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
-from django.db.models import Count, Q
+from django.db.models import Count
 
 from apps.mutations.models import (
-    ImportSource, StrainSource, StrainMutation, GeneLocus, Genome, StrainResistance,
-    Mutation, Paper, BioProject, Lineage, RESISTANCE, RESISTANCE_GROUP,
-)
+    ImportSource, StrainSource, StrainMutation, GeneLocus, StrainResistance,
+    Mutation, Paper, BioProject, RESISTANCE, RESISTANCE_GROUP)
 
 from .mixins import JsonView, DataSlicerMixin, DataTableMixin
-from .utils import GraphData, many_lookup, adjust_coords
+from .utils import GraphData, many_lookup
 from .models import Country, CountryHealth, CountryDetail
 
 def get_gdp(self, **_):
@@ -217,7 +216,8 @@ class DrugList(JsonView, DataSlicerMixin):
             'expected': expected,
         })
 
-    def estimate_correction(self, expected, sensitive_to_drug=0, intermediate=0, resistant_to_drug=0, **kw):
+    @staticmethod
+    def estimate_correction(expected, sensitive_to_drug=0, intermediate=0, resistant_to_drug=0, **kw):
         """Estimate the corrects"""
         sensitive = sensitive_to_drug
         resistant = intermediate + resistant_to_drug
@@ -241,19 +241,22 @@ class Lineages(JsonView, DataSlicerMixin):
         'drug[]': many_lookup(StrainResistance, 'drug__code', 'strain_id'),
     }
 
-    def get_sublineages(self, lin):
+    @staticmethod
+    def get_sublineages(lin):
         """Returns list of all ancestors of `lin`, including `lin` (e.g. '3.6.4' -> ['3', '3.6', '3.6.4'])"""
         dot_indices = [idx for idx, ch in enumerate(lin) if ch == '.']
         return [lin[:idx] for idx in dot_indices] + [lin]
 
-    def child_index(self, lin, children):
+    @staticmethod
+    def child_index(lin, children):
         """Returns index of child in `children` whose lineage is `lin`"""
         for idx, child in enumerate(children):
             if child['name'][1:] == lin:
                 return idx
 
 
-    def get_color(self, depth, idx):
+    @staticmethod
+    def get_color(depth, idx):
         """Returns color of sunburst arc given depth and clockwise index.
            Arcs follow a blue->green gradient clockwise, with lower opacity at higher levels"""
         if depth == 0:

--- a/apps/mutations/admin.py
+++ b/apps/mutations/admin.py
@@ -88,7 +88,8 @@ class MutationAdmin(ModelAdmin):
     list_filter = ('drugs',)
     search_fields = ('name', 'old_id')
 
-    def drugs_list(self, obj):
+    @staticmethod
+    def drugs_list(obj):
         return ", ".join(obj.drugs.values_list('code', flat=True))
 
 site.register(TargetSet)

--- a/apps/mutations/csv_lookups.py
+++ b/apps/mutations/csv_lookups.py
@@ -22,8 +22,6 @@ used to look data up.
 
 Features data conversion, sub table support and column naming.
 """
-
-import sys
 import logging
 
 from collections import OrderedDict
@@ -81,7 +79,7 @@ class BaseLookup(dict):
                 try:
                     self.append(dict(zip(header, row)))
                 except ValueError as err:
-                    logging.warning("%s:%d %s" % (filename, line+2, str(err)))
+                    logging.warning("%s:%d %s", filename, line+2, str(err))
 
     def set_type(self, key, value):
         """Some of the data in the file isn't a string, parse it"""
@@ -164,7 +162,7 @@ class BaseLookup(dict):
         for name in row:
             if row[name] is None:
                 continue
-            elif self[key][name] is None:
+            if self[key][name] is None:
                 self[key][name] = row[name]
             elif row[name] != self[key][name]:
                 raise KeyError("Duplicate key with different data: %s=%s %s=(%s!=%s)" % (self.key, key, name, self[key][name], row[name]))
@@ -182,7 +180,7 @@ class Lookup(BaseLookup):
 
         if delimiter is None:
             ext = filename.rsplit('.', 1)[-1]
-            delimiter = self.auto_delim.get(ext, None)
+            delimiter = self.auto_delim.get(ext)
 
         if delimiter is not None:
             self.delimiter = delimiter

--- a/apps/mutations/fields.py
+++ b/apps/mutations/fields.py
@@ -20,7 +20,6 @@ Input fields for manual mutation entry.
 
 from django.forms.fields import CharField
 from django.forms.widgets import Textarea
-from django.conf import settings
 
 class ListerWidget(Textarea):
     class Media:

--- a/apps/mutations/forms.py
+++ b/apps/mutations/forms.py
@@ -22,17 +22,14 @@ import os
 
 from django.conf import settings
 from django.db.models import Q
-from django.utils.html import escape
-from django.urls import reverse
-from django.contrib.admin.sites import site
-from django.contrib.admin.widgets import FilteredSelectMultiple, ForeignKeyRawIdWidget
+from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.forms import (
     Form, ModelForm, CharField, Textarea, ModelMultipleChoiceField, ValidationError
 )
 
 from apps.uploads.fields import UploadField
 
-from .models import Drug, GeneLocus, Mutation, ImportSource, ImportStrain, GeneDrugInteraction
+from .models import Drug, GeneLocus, Mutation, ImportSource, ImportStrain
 from .utils import unpack_mutation_format
 
 class DrugForm(ModelForm):

--- a/apps/mutations/management/commands/process_imports.py
+++ b/apps/mutations/management/commands/process_imports.py
@@ -6,7 +6,7 @@ from vcf import VCFReader
 
 from django.db import transaction
 from django.db.utils import DataError
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from apps.maps.models import Country, Place
 from apps.maps.utils import COUNTRY_MAP, CITY_MAP
@@ -15,9 +15,7 @@ from apps.uploads.models import UploadFile
 from apps.mutations.csv_lookups import Lookup as CsvLookup
 from apps.mutations.models import (
     ImportSource, Genome, Lineage, Paper, Drug,
-    StrainSource, BioProject, GeneLocus,
-    StrainMutation,
-)
+    StrainSource, BioProject, GeneLocus)
 from apps.mutations.utils import *
 
 LOGGER = logging.getLogger('apps.mutations')
@@ -182,7 +180,8 @@ class Command(BaseCommand):
         self.save_mutations(strain, var)
         return name
 
-    def save_mutations(self, strain, var):
+    @staticmethod
+    def save_mutations(strain, var):
         """Save all the mutations in the var file"""
         for snp in var.values():
             #gene = snp['regionid1']

--- a/apps/mutations/management/commands/update_locus.py
+++ b/apps/mutations/management/commands/update_locus.py
@@ -6,9 +6,7 @@ Gene Locus database.
 import logging
 from collections import OrderedDict
 
-from django.core.management.base import BaseCommand, CommandError
-
-from apps.mutations.models import GeneLocus
+from django.core.management.base import BaseCommand
 
 LOGGER = logging.getLogger('apps.mutations')
 
@@ -29,7 +27,8 @@ class Command(BaseCommand):
         with open(filename, 'r') as fhl:
             self.process_data(fhl.read().split('\n'))
 
-    def process_data(self, data):
+    @staticmethod
+    def process_data(data):
         drugs = OrderedDict()
         drug = None
         for item in data:
@@ -41,7 +40,7 @@ class Command(BaseCommand):
                 DRUGS[drug] = []
                 continue
             if not drug:
-                logging.warning("Drug missing in mutation list (%s)." % item)
+                logging.warning("Drug missing in mutation list (%s).", item)
                 continue
 
             (x, result) = item.split(' ', 1)

--- a/apps/mutations/migrations/0001_initial.py
+++ b/apps/mutations/migrations/0001_initial.py
@@ -46,10 +46,10 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='mutation',
-            unique_together=set([('gene_locus', 'name')]),
+            unique_together={('gene_locus', 'name')},
         ),
         migrations.AlterUniqueTogether(
             name='genelocus',
-            unique_together=set([('drug', 'name')]),
+            unique_together={('drug', 'name')},
         ),
     ]

--- a/apps/mutations/migrations/0002_auto_20161118_1041.py
+++ b/apps/mutations/migrations/0002_auto_20161118_1041.py
@@ -218,11 +218,11 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='genelocus',
-            unique_together=set([]),
+            unique_together=set(),
         ),
         migrations.AlterUniqueTogether(
             name='mutation',
-            unique_together=set([]),
+            unique_together=set(),
         ),
         migrations.AddField(
             model_name='targetregion',

--- a/apps/mutations/migrations/0003_migrate_drug_relationships.py
+++ b/apps/mutations/migrations/0003_migrate_drug_relationships.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from collections import defaultdict
-from django.db import models, migrations
+from django.db import migrations
 
 def to_drug_mutations(apps, schema_editor):
     """Move the drug<->mutation relationship to a ManyToMany field and remove duplicate mutations"""
@@ -18,7 +18,7 @@ def to_drug_mutations(apps, schema_editor):
     for pkg in Drug.objects.values('pk', 'gene_locuses__mutations__name'):
         drug_mutations[pkg['pk']].add(pkg['gene_locuses__mutations__name'])
 
-    unique_locus = dict()
+    unique_locus = {}
     for locus in GeneLocus.objects.all():
         if locus.name in unique_locus:
             # Add all of these mutations to the master locus
@@ -31,7 +31,7 @@ def to_drug_mutations(apps, schema_editor):
             locus.genome = genome
             locus.save()
 
-    unique_mutations = dict()
+    unique_mutations = {}
     for mutation in Mutation.objects.all():
         if mutation.name in unique_mutations:
             # Delete this duplicate mutation name

--- a/apps/mutations/migrations/0004_auto_20161118_1054.py
+++ b/apps/mutations/migrations/0004_auto_20161118_1054.py
@@ -13,11 +13,11 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterUniqueTogether(
             name='genelocus',
-            unique_together=set([('genome', 'name')]),
+            unique_together={('genome', 'name')},
         ),
         migrations.AlterUniqueTogether(
             name='mutation',
-            unique_together=set([('gene_locus', 'name')]),
+            unique_together={('gene_locus', 'name')},
         ),
         migrations.RemoveField(
             model_name='genelocus',

--- a/apps/mutations/migrations/0014_auto_20181107_1148.py
+++ b/apps/mutations/migrations/0014_auto_20181107_1148.py
@@ -19,6 +19,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='strainmutation',
-            unique_together=set([('strain', 'mutation')]),
+            unique_together={('strain', 'mutation')},
         ),
     ]

--- a/apps/mutations/migrations/0017_auto_20190208_1503.py
+++ b/apps/mutations/migrations/0017_auto_20190208_1503.py
@@ -42,6 +42,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='genedruginteraction',
-            unique_together=set([('drug', 'gene', 'paper')]),
+            unique_together={('drug', 'gene', 'paper')},
         ),
     ]

--- a/apps/mutations/models.py
+++ b/apps/mutations/models.py
@@ -25,7 +25,7 @@ import os
 from django.conf import settings
 from django.db.models import Model, Manager, Q, QuerySet, \
     CharField, PositiveIntegerField, ForeignKey, ManyToManyField, URLField, \
-    SlugField, IntegerField, SmallIntegerField, BooleanField, DateField, DateTimeField, \
+    SlugField, IntegerField, BooleanField, DateField, DateTimeField, \
     TextField, DecimalField, CASCADE, SET_NULL
 from django.urls import reverse
 
@@ -150,7 +150,7 @@ class GeneLocusManager(Manager):
         loci = self.filter(start__lte=pos, stop__gte=pos)
         if loci.count() == 1:
             return loci.get()
-        elif loci.count() == 0:
+        if loci.count() == 0:
             return None
 
         # Overlapping loci, try and detect what we have
@@ -164,7 +164,7 @@ class GeneLocusManager(Manager):
         lk_b = second.name.lower() in symbol or str(second.gene_symbol).lower() in symbol
         if (is_a and not is_b) or (lk_a and not lk_b):
             return first
-        elif (is_b and not is_a) or (lk_b and not lk_a):
+        if (is_b and not is_a) or (lk_b and not lk_a):
             return second
 
         return None
@@ -258,7 +258,8 @@ class GeneDrugInteraction(Model):
 
 
 class MutationQuerySet(QuerySet):
-    def variant_names(self):
+    @staticmethod
+    def variant_names():
         """Returns a list of mutations involved in predictions"""
         # Disabled while the database and RandomForest are incongruent
         #names = self.values_list('name', flat=True)

--- a/apps/mutations/utils.py
+++ b/apps/mutations/utils.py
@@ -241,11 +241,11 @@ def unpack_mutation_format(name):
         if snp.get('noncode', '') != 'promoter':
             _ = ValueError("Promoter doesn't specify 'promoter' part in %s" % name)
         return (index, 'promoter ' + gene, name)
-    elif snp['syn'] == 'I':
+    if snp['syn'] == 'I':
         if snp.get('noncode', '') != 'inter':
             _ = ValueError("Integenic doesn't specify 'inter' part")
         return (index, 'intergenic ' + gene, name)
-    elif snp['syn'] in ['CN', 'CD', 'CF', 'CI', 'CS', 'CZ', 'N', 'ND', 'NI', 'NF']:
+    if snp['syn'] in ['CN', 'CD', 'CF', 'CI', 'CS', 'CZ', 'N', 'ND', 'NI', 'NF']:
         return (index, gene, name)
     raise ValueError("Must be promoter, intergenic or CN, CD, CF, CI, CS, CZ or N, ND, NI, NF")
 
@@ -321,8 +321,8 @@ def file_generator(*required, **_):
                 raise FileNotFound("File '%s' Not Found" % filename)
 
             # Get the right content unpacker
-            _loader = LOADERS.get(kw.get('loader', None), None)\
-                   or LOADERS.get(filename.rsplit('.', 1)[-1], None)
+            _loader = LOADERS.get(kw.get('loader', None))\
+                   or LOADERS.get(filename.rsplit('.', 1)[-1])
             if _loader is None:
                 raise TypeError("Can't parse '%s' unknown type." % filename)
 
@@ -417,7 +417,7 @@ def long_match(MAP, d, value, model=None, default='NOP', *cols, **filt):
     return d[value]
 
 
-class StatusBar(object):
+class StatusBar():
     """A generic command line status bar, use like so:
 
     for item in StatusBar("Label:", 300, looper_function):

--- a/apps/mutations/views.py
+++ b/apps/mutations/views.py
@@ -25,7 +25,6 @@ from collections import defaultdict
 from apps.maps.mixins import JsonView
 
 from django.views.generic import TemplateView, FormView, DetailView, ListView
-from django.urls import reverse
 
 from .models import ImportSource, Mutation
 from .forms import DataUploaderForm

--- a/apps/pipeline/admin.py
+++ b/apps/pipeline/admin.py
@@ -21,9 +21,9 @@ from django.utils.safestring import mark_safe
 try:
     from adminsortable2.admin import SortableAdminMixin, SortableInlineAdminMixin
 except ImportError:
-    class SortableAdminMixin(object):
+    class SortableAdminMixin():
         pass
-    class SortableInlineAdminMixin(object):
+    class SortableInlineAdminMixin():
         pass
 
 from .models import *
@@ -83,7 +83,8 @@ class PipelineRunAdmin(admin.ModelAdmin):
     list_filter = ['pipeline']
     inlines = (ProgramRunInline,)
 
-    def status(self, obj):
+    @staticmethod
+    def status(obj):
         for prog in obj.programs.all():
             if prog.is_complete:
                 continue
@@ -95,16 +96,19 @@ class PipelineRunAdmin(admin.ModelAdmin):
                 return 'Waiting: %s' % str(prog.program)
         return "Complete"
 
-    def age(self, obj):
+    @staticmethod
+    def age(obj):
         if obj.modified and obj.created:
             return obj.modified - obj.created
         return '-'
 
+    @staticmethod
     def all_stop(modeladmin, request, queryset):
         for run in queryset.all():
             run.stop_all(msg='Admin Stopped this Program')
     all_stop.short_description = "Emergency All Stop"
 
+    @staticmethod
     def force_update(modeladmin, request, queryset):
         for run in queryset.all():
             for program in run.programs.all():

--- a/apps/pipeline/management/commands/test_pipeline.py
+++ b/apps/pipeline/management/commands/test_pipeline.py
@@ -7,7 +7,7 @@ import time
 import datetime
 
 from django.core.management.base import BaseCommand
-from apps.pipeline.models import Pipeline, PipelineRun
+from apps.pipeline.models import Pipeline
 
 
 class PipelineDoesNotExist(Exception):
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         rows = []
 
         # longest string in each column
-        cmax = dict()
+        cmax = {}
 
         for l in labels:
             cmax[l] = len(l)

--- a/apps/pipeline/migrations/0005_remove_program_requirements.py
+++ b/apps/pipeline/migrations/0005_remove_program_requirements.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations, models
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/apps/pipeline/models.py
+++ b/apps/pipeline/models.py
@@ -446,14 +446,14 @@ class PipelineRun(TimeStampedModel):
     def all_programs(self):
         """Returns all the program runs with unrun pipelines appended"""
         ret = []
-        runs = dict((p.program_id, p) for p in self.programs.all())
+        runs = {p.program_id: p for p in self.programs.all()}
         for pipe in self.pipeline.programs.all():
             ret.append(runs.get(pipe.program_id, pipe))
         return ret
 
     def stop_all(self, msg='All Stopped'):
         """Forcefully stop all processes in this pipeline run"""
-        return all([program.stop(msg=msg) for program in self.programs.all()])
+        return all(program.stop(msg=msg) for program in self.programs.all())
 
     def update_all(self):
         """
@@ -461,7 +461,7 @@ class PipelineRun(TimeStampedModel):
         True if all programs are complete. False if any are still running.
         """
         qset = self.programs.filter(Q(is_submitted=False) | Q(is_complete=False))
-        if all([program.update_status() for program in qset]):
+        if all(program.update_status() for program in qset):
             if qset.count():
                 # Clean up step for all programs
                 self.delete_output_files()
@@ -750,7 +750,8 @@ class ProgramRun(TimeStampedModel):
             return -1
         return max([keep_for - self.output_age(), 0])
 
-    def update_size(self, *files):
+    @staticmethod
+    def update_size(*files):
         """Takes a list of files as a string and returns the size in Kb"""
         return 0 + sum([os.path.getsize(fn) for fn in files])
 

--- a/apps/pipeline/views.py
+++ b/apps/pipeline/views.py
@@ -46,7 +46,8 @@ class PipelineDetail(ProtectedMixin, DetailView): # pylint: disable=too-many-anc
             for_test=True, commit=False, file='file')
         return data
 
-    def get_parent(self):
+    @staticmethod
+    def get_parent():
         return (reverse('pipeline:pipelines'), "Pipelines")
 
 class DiskUsage(ProtectedMixin, ListView):
@@ -158,7 +159,7 @@ class JobViewer(ProtectedMixin, TemplateView):
             kw['end'] = (date.today() + timedelta(days=1)).isoformat()
 
         if 'col' in self.request.GET:
-            cols = [c for c in self.request.GET.getlist('col')]
+            cols = list(self.request.GET.getlist('col'))
         else:
             cols = [c for c in self.request.GET.get('cols', '').split(',') if c]
 

--- a/apps/predict/admin.py
+++ b/apps/predict/admin.py
@@ -47,6 +47,7 @@ class PredictDatasetAdmin(admin.ModelAdmin):
     readonly_fields = [ 'created', 'modified', 'md5', 'file_directory',
                         'user_name', 'user_email', 'user_affiliation',]
 
+    @staticmethod
     def retry_processes(modeladmin, request, queryset):
         for predict in queryset.all():
             for strain in predict.strains.all():

--- a/apps/predict/forms.py
+++ b/apps/predict/forms.py
@@ -62,7 +62,7 @@ class UploadForm(ModelForm):
         pl.queryset = self.pipeline_queryset()
         if pl.queryset.count() == 0:
             raise ValueError("No pipeline for type '%s'" % self.my_file_type)
-        elif pl.queryset.count() == 1:
+        if pl.queryset.count() == 1:
             pl.widget = HiddenInput()
             pl.initial = pl.queryset.get().pk
         else:
@@ -210,10 +210,12 @@ class NotificationForm(Form):
     result_data = CharField(widget=Textarea, required=False)
 
     def was_run_successful(self):
-        assert hasattr(self, 'cleaned_data'), "Must have is_valid() == true.  cleaned_data not found"
+        if not hasattr(self, 'cleaned_data'):
+            raise AssertionError("Must have is_valid() == true.  cleaned_data not found")
         return self.cleaned_data['success']
 
     def get_result_data(self):
-        assert hasattr(self, 'cleaned_data'), "Must have is_valid() == true.  cleaned_data not found"
+        if not hasattr(self, 'cleaned_data'):
+            raise AssertionError("Must have is_valid() == true.  cleaned_data not found")
         return self.cleaned_data['result_data']
 

--- a/apps/predict/management/commands/submit_predict.py
+++ b/apps/predict/management/commands/submit_predict.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from django.core.management.base import BaseCommand
 from django.contrib.sites.models import Site
 from django.template.loader import get_template
-from django.template import Context
 from django.core.mail import send_mail
 from django.conf import settings
 

--- a/apps/predict/migrations/0007_auto_20170202_1539.py
+++ b/apps/predict/migrations/0007_auto_20170202_1539.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations, models
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/apps/predict/migrations/0011_remove_predictdataset_status.py
+++ b/apps/predict/migrations/0011_remove_predictdataset_status.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations, models
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/apps/predict/mixins.py
+++ b/apps/predict/mixins.py
@@ -7,7 +7,7 @@ from django.contrib.auth.decorators import login_required
 
 from .models import PredictDataset
 
-class PredictMixin(object):
+class PredictMixin():
     """The baseline predict view"""
     slug_field = 'md5'
 

--- a/apps/predict/models.py
+++ b/apps/predict/models.py
@@ -18,8 +18,6 @@
 Provide prediction app using the pipeline for building predictions and the
 uploads app to download large data files from the users.
 """
-
-import sys
 import json
 import logging
 
@@ -28,7 +26,7 @@ from hashlib import md5
 import os
 from os.path import join, isdir, basename
 
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 from datetime import timedelta
 
 from model_utils.models import TimeStampedModel
@@ -159,17 +157,17 @@ class PredictDataset(TimeStampedModel):
     @property
     def has_prediction(self):
         """Returns true if any strain has a predict file"""
-        return any([strain.has_prediction for strain in self.strains.all()])
+        return any(strain.has_prediction for strain in self.strains.all())
 
     @property
     def has_lineages(self):
         """Return true if any strain has a lineage file"""
-        return any([strain.has_lineage for strain in self.strains.all()])
+        return any(strain.has_lineage for strain in self.strains.all())
 
     @property
     def has_output_files(self):
         """Return true if any strain has output files"""
-        return any([list(strain.output_files) for strain in self.strains.all()])
+        return any(list(strain.output_files) for strain in self.strains.all())
 
     @property
     def time_taken(self):
@@ -462,10 +460,9 @@ class PredictStrain(Model):
             # Very old format lineages
             if data and data[0] == '\t':
                 return list(lineage_spoligo(data.split('\t')))
-            elif '\t' in data:
+            if '\t' in data:
                 return list(lineage_fast_caller(data))
-            else:
-                return list(lineage_other_caller(data))
+            return list(lineage_other_caller(data))
         return []
 
     @property
@@ -493,7 +490,8 @@ class PredictStrain(Model):
             except Exception:
                 yield None, False
 
-    def _prediction_from_file(self, matrix_fn):
+    @staticmethod
+    def _prediction_from_file(matrix_fn):
         m_A, m_B, m_C, m_D = {}, {}, {}, {}
         with open(matrix_fn, 'r') as fhl:
             parts = json.loads(fhl.read())

--- a/apps/predict/urls.py
+++ b/apps/predict/urls.py
@@ -28,7 +28,7 @@ from .views import (
 )
 
 def url_tree(regex, *urls):
-    class UrlTwig(object):
+    class UrlTwig():
         urlpatterns = urls
     return url(regex, include(UrlTwig))
 

--- a/apps/predict/views.py
+++ b/apps/predict/views.py
@@ -8,9 +8,7 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 from django.views.generic import (
-    DetailView, ListView, CreateView, UpdateView, FormView,
-    TemplateView,
-)
+    DetailView, ListView, CreateView, TemplateView)
 from django.views.generic.detail import SingleObjectMixin
 from django.urls import reverse
 from django.http.response import JsonResponse
@@ -111,7 +109,8 @@ class AddNote(PredictMixin, CreateView):
 class ScatterPlot(JsonView, SingleObjectMixin):
     model = PredictResult
 
-    def build_loci_list(self, drug, dataset):
+    @staticmethod
+    def build_loci_list(drug, dataset):
         """
         Compile a list of all loci for this drug used in the dataset.
         """

--- a/apps/tb_users/auth_urls.py
+++ b/apps/tb_users/auth_urls.py
@@ -22,7 +22,7 @@ from django.contrib.auth.views import (
 )
 
 def url_tree(regex, *urls):
-    class UrlTwig(object):
+    class UrlTwig():
         urlpatterns = urls
     return url(regex, include(UrlTwig))
 

--- a/apps/tb_users/forms.py
+++ b/apps/tb_users/forms.py
@@ -1,9 +1,8 @@
 from django.utils.translation import ugettext as _
-import re
 
 from django import forms
 from django.contrib.auth.models import User
-from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
+from django.contrib.auth.forms import UserCreationForm
 
 from apps.tb_users.models import TBUser
 

--- a/apps/tb_users/mixins.py
+++ b/apps/tb_users/mixins.py
@@ -23,7 +23,7 @@
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied
 
-class ProtectedMixin(object):
+class ProtectedMixin():
     """Combine login required and permission specific as one mixin"""
     def is_permitted(self, user):
         """Is the user allowed to access this resource"""

--- a/apps/uploads/admin.py
+++ b/apps/uploads/admin.py
@@ -7,7 +7,8 @@ class UploadFileAdmin(admin.ModelAdmin):
     list_display = ('title', 'get_type', 'flag', 'size', 'created', 'retrieval_start', 'retrieval_end', 'retrieval_error')
     save_on_top = True
 
-    def title(self, obj):
+    @staticmethod
+    def title(obj):
         """Returns the uploads name plus icon (if available)"""
         if obj.icon:
             return mark_safe("<img src='{0.icon}' style='width: 2em; vertical-align: middle;'> {0.name}".format(obj))

--- a/apps/uploads/app.py
+++ b/apps/uploads/app.py
@@ -1,7 +1,5 @@
-import logging
 from django.db.models import signals
 from django.apps import AppConfig
-from django.conf import settings
 
 class UploadsConfig(AppConfig):
     name = 'apps.uploads'

--- a/apps/uploads/fields.py
+++ b/apps/uploads/fields.py
@@ -31,7 +31,7 @@ class UploadField(Field):
 
     def __init__(self, **kw):
         self.directory = kw.pop('dir', None)
-        self.extensions = kw.get('extensions', None)
+        self.extensions = kw.get('extensions')
         if 'widget' not in kw:
             kw['widget'] = self.widget(
                 extensions=kw.pop('extensions', None),

--- a/apps/uploads/files.py
+++ b/apps/uploads/files.py
@@ -31,7 +31,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import FileSystemStorage
 from django.conf import settings
 
-class ResumableFile(object):
+class ResumableFile():
     """A resumable file controls getting pieces of a file"""
     upload_root = getattr(settings, 'UPLOAD_ROOT', None)
     name_template = "part_%(resumableChunkNumber)04d.tmp"

--- a/apps/uploads/management/commands/process_uploads.py
+++ b/apps/uploads/management/commands/process_uploads.py
@@ -2,7 +2,7 @@
 import logging
 
 from django.utils.timezone import now
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from apps.uploads.models import DropboxUploadFile, ManualUploadFile, ResumableUploadFile
 
 LOGGER = logging.getLogger('apps.uploads')

--- a/apps/uploads/models.py
+++ b/apps/uploads/models.py
@@ -24,8 +24,8 @@ import logging
 
 from django.conf import settings
 from django.db.models import (
-    Model, Manager, QuerySet, SlugField, CharField, PositiveIntegerField, URLField,
-    DateTimeField, TextField, ForeignKey, CASCADE, SET_NULL, Sum
+    Model, QuerySet, SlugField, CharField, PositiveIntegerField, URLField,
+    DateTimeField, TextField, ForeignKey, CASCADE, Sum
 )
 from django.utils.timezone import now
 

--- a/apps/uploads/utils.py
+++ b/apps/uploads/utils.py
@@ -37,7 +37,7 @@ def get_uuid():
     """Return the hex from a new uuid4 uuid"""
     return uuid.uuid4().hex
 
-class ManagedUrl(object):
+class ManagedUrl():
     """
     Manages a URL so that it can be fed back to a user's session safely.
     It takes a url that has a password and caches the details to disk before
@@ -50,7 +50,8 @@ class ManagedUrl(object):
             with open(self._cache_file(self.url.netloc.encode('utf8'))) as fhl:
                 self.url = self.url._replace(**json.loads(fhl.read()))
 
-    def _cache_file(self, digest):
+    @staticmethod
+    def _cache_file(digest):
         """Return the location of the cached url"""
         return os.path.join(settings.UPLOAD_CACHE_ROOT, digest + '.json')
 
@@ -84,7 +85,7 @@ class ManagedUrl(object):
 
 
 
-class Download(object): 
+class Download(): 
     """Wrap the requests module for django's storage backend."""
     _requests = None
 

--- a/apps/versioner/utils.py
+++ b/apps/versioner/utils.py
@@ -34,7 +34,7 @@ def context_items(context):
         for (key, value) in d.items():
             yield (key, value)
 
-class BaseMiddleware(object):
+class BaseMiddleware():
     """ 
     When used by a middleware class, provides a predictable get()
     function which will provide the first available variable from
@@ -46,7 +46,8 @@ class BaseMiddleware(object):
     def __call__(self, request):
         return self.get_response(request)
 
-    def get(self, data, key, default=None, then=None):
+    @staticmethod
+    def get(data, key, default=None, then=None):
         """Returns a data key from the context_data, the view, a get
         method on the view or a get method on the middleware in that order.
         

--- a/bin/checkd.py
+++ b/bin/checkd.py
@@ -35,7 +35,7 @@ def main():
 
     # nonzero exit for GenTB Pipeline
     if (valid / num_lines) < 0.95:
-        exit(1)
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/bin/classify.py
+++ b/bin/classify.py
@@ -39,7 +39,7 @@ def main():
             tbperc = float(percent.group(0)) / 100
 
             if tbperc < 0.9:
-                exit(1)
+                sys.exit(1)
 
             break
 

--- a/bin/qc_report.py
+++ b/bin/qc_report.py
@@ -25,7 +25,6 @@ back to stdout for pipeline processing.
 
 import os
 import sys
-import atexit
 
 
 def test_quality(name, fhl, threshold=15):
@@ -48,9 +47,8 @@ def test_quality(name, fhl, threshold=15):
     if pc < 2:
         sys.stderr.write('PASS\n')
         return 0
-    else:
-        sys.stderr.write('FAIL : %d%% of the DR sites have coverage <%dx\n' % (pc, threshold))
-        return 1
+    sys.stderr.write('FAIL : %d%% of the DR sites have coverage <%dx\n' % (pc, threshold))
+    return 1
 
 
 def test_qc_file(filename, threshold=15):
@@ -69,7 +67,7 @@ if __name__ == '__main__':
         if arg.startswith('-Q='):
             threshold = int(arg.split('=')[-1])
             continue
-        elif os.path.isdir(arg):
+        if os.path.isdir(arg):
             for filename in os.listdir(arg):
                 if filename.endswith('.qc'):
                     failed += test_qc_file(filename, threshold)

--- a/bin/vcf_cutter.py
+++ b/bin/vcf_cutter.py
@@ -23,7 +23,7 @@ import sys
 # only one base
 def main():
     if len(sys.argv) < 2:
-        exit(1)
+        sys.exit(1)
 
     REF_IDX = -1
     ALT_IDX = -1

--- a/scripts/load_who_tb_burden_data.py
+++ b/scripts/load_who_tb_burden_data.py
@@ -2,7 +2,6 @@
 # pylint: disable=wrong-import-position
 # dataset from WHO: TB_burden_countries_2020-07-23.csv
 
-import requests
 import sys
 
 sys.path.insert(0, '.')

--- a/scripts/load_world_bank_gdp_data.py
+++ b/scripts/load_world_bank_gdp_data.py
@@ -15,8 +15,6 @@ except ImportError as err:
         "working directory, or is the environment not configured?:\n"\
         "{}\n".format(err))
     sys.exit(1)
-
-from apps.mutations.utils import csv_merge
 from apps.maps.models import Country, CountryHealth
 
 if __name__ == '__main__':

--- a/scripts/load_worldbank_pop_dens_data.py
+++ b/scripts/load_worldbank_pop_dens_data.py
@@ -15,8 +15,6 @@ except ImportError as err:
         "working directory, or is the environment not configured?:\n"\
         "{}\n".format(err))
     sys.exit(1)
-
-from apps.mutations.utils import csv_merge
 from apps.maps.models import Country, CountryHealth
 
 if __name__ == '__main__':

--- a/scripts/load_worldbank_totalwealth_data.py
+++ b/scripts/load_worldbank_totalwealth_data.py
@@ -15,8 +15,6 @@ except ImportError as err:
         "working directory, or is the environment not configured?:\n"\
         "{}\n".format(err))
     sys.exit(1)
-
-from apps.mutations.utils import csv_merge
 from apps.maps.models import Country, CountryHealth
 
 if __name__ == '__main__':

--- a/scripts/o2_based_import.py
+++ b/scripts/o2_based_import.py
@@ -46,7 +46,7 @@ class NotEnrichedError(ValueError):
     """The VCF File isn't enriched, so can't be imported"""
 
 
-class Command(object):
+class Command():
     """Import VCF and JSON based strain data"""
     # Caches
     countries = EMPTY.copy()
@@ -133,7 +133,8 @@ class Command(object):
             for reason, count in self.log['ok'].items():
                 print(f" * {reason}: {count}")
 
-    def annotate_vcf(self, var_fhl, vcf_path):
+    @staticmethod
+    def annotate_vcf(var_fhl, vcf_path):
         """
         Call the flat annotator and block until we're finished.
         """

--- a/scripts/update_mutation_locus.py
+++ b/scripts/update_mutation_locus.py
@@ -79,7 +79,7 @@ def set_gene_locus(mut):
         merge_model_objects(mut, list(others), keep_old=True)
         total, counts = others.delete()
         counts.pop('mutations.Mutation', None)
-        if set(counts.values()) != set([0]):
+        if set(counts.values()) != {0}:
             print("Deleted some unexpected values when merging mutations: {}".format(counts))
             sys.exit(1)
 

--- a/scripts/update_mutation_names.py
+++ b/scripts/update_mutation_names.py
@@ -20,7 +20,7 @@ except ImportError as err:
 from argparse import ArgumentParser
 from apps.mutations.models import Mutation
 
-class Command(object):
+class Command():
     """Check all mutation names and format the data as needed."""
     def __init__(self):
         self.arg_parser = ArgumentParser(description=self.__doc__)

--- a/tb_website/management/commands/showurls.py
+++ b/tb_website/management/commands/showurls.py
@@ -4,11 +4,11 @@ Shows all the available urls for a django website, useful for debugging.
 
 import types
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 import tb_website.urls
 
-class Url(object):
+class Url():
     is_module = False
     is_view = False
 
@@ -33,7 +33,7 @@ class Url(object):
         namespace = self.namespace
         if name and namespace:
             return "%s:%s" % (namespace, name)
-        elif name:
+        if name:
             return name
         return None
 
@@ -97,7 +97,7 @@ class UrlModule(Url):
     def urls_name(self, uc):
         if isinstance(uc, list) and uc:
             return self.urls_name(uc[0])
-        elif hasattr(uc, '__name__'):
+        if hasattr(uc, '__name__'):
             return uc.__name__
         return None
 
@@ -107,7 +107,7 @@ class UrlFunction(Url):
         tag = super(UrlFunction, self).__str__()
         return "%s > %s()" % (tag, self.module.__name__)
 
-class WebsiteUrls(object):
+class WebsiteUrls():
     """A class that can loop through urls in a tree structure"""
     def __iter__(self):
         """

--- a/tb_website/middleware.py
+++ b/tb_website/middleware.py
@@ -38,7 +38,7 @@ def IterObject(typ=list): # pylint: disable=invalid-name
         return __inner__
     return __outer__
 
-class AutoBreadcrumbMiddleware(object):
+class AutoBreadcrumbMiddleware():
     """
     This middleware controls and inserts some breadcrumbs
     into most pages. It attempts to navigate object hierachy
@@ -60,7 +60,8 @@ class AutoBreadcrumbMiddleware(object):
         response = self.get_response(request)
         return response
 
-    def get(self, data, key, default=None, then=None):
+    @staticmethod
+    def get(data, key, default=None, then=None):
         """Returns a data key from the context_data, the view, a get
         method on the view or a get method on the middleware in that order.
         
@@ -87,7 +88,8 @@ class AutoBreadcrumbMiddleware(object):
         response.context_data['admin_link'] = self.get_admin_link(request.user, data)
         return response
 
-    def get_admin_link(self, user, data):
+    @staticmethod
+    def get_admin_link(user, data):
         """Generates an admin link to edit this object"""
         obj = data.get('object', None)
         if obj is not None and user is not None:
@@ -99,7 +101,8 @@ class AutoBreadcrumbMiddleware(object):
                     'url': reverse(f'admin:{ct.app_label}_{ct.model}_change', args=args),
                 }
 
-    def get_title(self, data):
+    @staticmethod
+    def get_title(data):
         """If no title specified in context, use last breadcrumb"""
         if data.get('breadcrumbs', False):
             return list(data['breadcrumbs'])[-1][-1]
@@ -152,7 +155,8 @@ class AutoBreadcrumbMiddleware(object):
                 yield ans
         yield obj
 
-    def object_link(self, obj):
+    @staticmethod
+    def object_link(obj):
         """Get name from object model"""
         url = None
         if obj is None or (isinstance(obj, tuple) and len(obj) == 2):

--- a/tb_website/routers.py
+++ b/tb_website/routers.py
@@ -2,20 +2,23 @@
 from django.conf import settings
 DB = list(settings.DATABASES)
 
-class PrivateAppRouter(object):
+class PrivateAppRouter():
     """
     Allows an app to have it's own private database if needed
     """
-    def db_for_read(self, model, **hints):
+    @staticmethod
+    def db_for_read(model, **hints):
         if model._meta.app_label in DB:
             return model._meta.app_label
     db_for_write = db_for_read
 
-    def allow_relation(self, obj1, obj2, **hints):
+    @staticmethod
+    def allow_relation(obj1, obj2, **hints):
         if obj1._state.db == obj2._state.db:
             return True
         return None
 
-    def allow_migrate(self, db, app_label, model_name=None, **hints):
+    @staticmethod
+    def allow_migrate(db, app_label, model_name=None, **hints):
         return app_label not in DB
 

--- a/tb_website/serializers.py
+++ b/tb_website/serializers.py
@@ -20,7 +20,7 @@ from .utils import sizeof, to
 class Serializer(BaseSerializer):
     pass
 
-class ProgressiveLoader(object):
+class ProgressiveLoader():
     reject_fhl = None
 
     def __init__(self, fhl, pos=1):
@@ -74,7 +74,7 @@ class ProgressiveLoader(object):
             cls.reject_fhl.write("]")
             cls.reject_fhl.close()
 
-class BigDeserializer(object):
+class BigDeserializer():
     field_names_cache = {}
 
     def __init__(self, ranges=None, attempt=1):
@@ -173,7 +173,8 @@ class BigDeserializer(object):
             return None # Any error, defer the object.
 
     @to(dict)
-    def build_data(self, model, field_names, pk, data, using=None):
+    @staticmethod
+    def build_data(model, field_names, pk, data, using=None):
         m2m = {}
         if pk is not None:
             try:

--- a/tb_website/settings/manage.py
+++ b/tb_website/settings/manage.py
@@ -2,7 +2,6 @@
 MANAGER_DB = None
 
 from .local import *
-import sys
 
 #sys.stderr.write("Manager Django Backend!\n")
 


### PR DESCRIPTION
- Remove unnecessary use of comprehension
- Remove unused imports
- Refactor unnecessary `else` / `elif` when `if` block has a `return` statement
- Use `sys.exit()` calls
- Refactor unnecessary `else` / `elif` when `if` block has a `continue` statement
- Change methods not using its bound instance to staticmethods
- Use literal syntax instead of function calls to create data structure
- Remove unnecessary comprehension
- Remove implicit `object` from the base class
- Pass string format arguments as logging method parameters
- Remove assert statement from non-test files
- Refactor unnecessary `else` / `elif` when `if` block has a `return` statement
- Remove redundant `None` default
- Use literal syntax to create data structure
- Refactor unnecessary `else` / `elif` when `if` block has a `raise` statement
- Remove unnecessary generator