### PR TITLE
(maint): small fixes

### DIFF
--- a/apps/maps/mixins.py
+++ b/apps/maps/mixins.py
@@ -52,7 +52,7 @@ class DjangoJSONEncoder2(DjangoJSONEncoder):
             return {'__type__': 'datetime.timedelta',
                     'args': [getattr(obj, arg) for arg in args]}
         if isinstance(obj, QuerySet):
-            return [item for item in obj]
+            return list(obj)
         return DjangoJSONEncoder.default(self, obj)
 
 #Inherit from the parent class View and add Caching

--- a/apps/maptables/management/commands/load_custom_map.py
+++ b/apps/maptables/management/commands/load_custom_map.py
@@ -69,7 +69,7 @@ class Command(BaseCommand):
         if bad_countries:
             print(f" * WARNING: Could not match countries {bad_countries}, rows not imported")
         if not rows_added:
-            print(f" * CRITICAL: No rows added!")
+            print(" * CRITICAL: No rows added!")
         else:
             print(f"\n = Sucessfully imported {rows_added} rows =\n")
 

--- a/apps/maptables/models.py
+++ b/apps/maptables/models.py
@@ -27,7 +27,7 @@ class MapDataSource(Model):
     slug = SlugField(max_length=32)
     name = CharField(max_length=48)
     description = CharField(max_length=128, null=True, blank=True)
-    
+
     def __str__(self):
         return self.name
 
@@ -120,7 +120,7 @@ class MapDisplayDetail(Model):
     ))
 
     def __str__(self):
-        return f"DETAILS:[self.label]"
+        return f"DETAILS:{self.label}"
 
 FILTER_TYPES = (
     ('', 'No filter'),

--- a/apps/mutations/management/commands/count_strains.py
+++ b/apps/mutations/management/commands/count_strains.py
@@ -69,7 +69,7 @@ class Command(BaseCommand):
                 )
             count += 1
             if count > 1000:
-                print(f" [x] Created 1000 Counts")
+                print(" [x] Created 1000 Counts")
                 StrainMutationCount.objects.bulk_create(bulk)
                 total_count += count
                 count = 0

--- a/apps/mutations/models.py
+++ b/apps/mutations/models.py
@@ -164,8 +164,8 @@ class GeneLocusManager(Manager):
         symbol = name.replace('inter-', 'intergenic ')\
                      .replace('promoter_', 'promoter ')\
                      .split('_')[-1].lower()
-        is_a = str(first.gene_symbol).lower() == symbol or str(first.name).lower() == symbol
-        is_b = str(second.gene_symbol).lower() == symbol or str(second.name).lower() == symbol
+        is_a = symbol in (str(first.gene_symbol).lower(), str(first.name).lower())
+        is_b = symbol in (str(second.gene_symbol).lower(), str(second.name).lower())
         lk_a = first.name.lower() in symbol or str(first.gene_symbol).lower() in symbol
         lk_b = second.name.lower() in symbol or str(second.gene_symbol).lower() in symbol
         if (is_a and not is_b) or (lk_a and not lk_b):

--- a/apps/pipeline/views.py
+++ b/apps/pipeline/views.py
@@ -159,7 +159,7 @@ class JobViewer(ProtectedMixin, TemplateView):
             kw['end'] = (date.today() + timedelta(days=1)).isoformat()
 
         if 'col' in self.request.GET:
-            cols = [c for c in self.request.GET.getlist('col')]
+            cols = list(self.request.GET.getlist('col'))
         else:
             cols = [c for c in self.request.GET.get('cols', '').split(',') if c]
 

--- a/bin/checkd.py
+++ b/bin/checkd.py
@@ -35,7 +35,7 @@ def main():
 
     # nonzero exit for GenTB Pipeline
     if (valid / num_lines) < 0.95:
-        exit(1)
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/bin/checkd_DR.py
+++ b/bin/checkd_DR.py
@@ -36,10 +36,10 @@ def main():
     # nonzero exit for GenTB Pipeline
     td = valid / num_lines
     if td < 0.95:
-        sys.stderr.write("Error. Average depth across DR regions = ")
+        sys.stderr.write('Error. Average depth across DR regions = ')
         sys.stderr.write(str(td))
-        sys.stderr.write("\n")
-        exit(1)
+        sys.stderr.write('\n')
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/bin/classify.py
+++ b/bin/classify.py
@@ -39,7 +39,7 @@ def main():
             tbperc = float(percent.group(0)) / 100
 
             if tbperc < 0.9:
-                exit(1)
+                sys.exit(1)
 
             break
 

--- a/bin/generate_matrix.py
+++ b/bin/generate_matrix.py
@@ -89,7 +89,7 @@ def generate_matrix(variants, filename):
             elif parts[1] == 'P':
                 # promoter (to maintain compatibility with old naming used in
                 # randomforest built from MIP data
-                operon = parts[len(parts)-1].split('-')
+                operon = parts[-1].split('-')
                 #sys.stderr.write(str(operon))
                 if operon[0] == "promoter":
                     pattern = parts[3] + '_' + operon[0] + '_' + operon[1]

--- a/bin/vcf_cutter.py
+++ b/bin/vcf_cutter.py
@@ -23,7 +23,7 @@ import sys
 # only one base
 def main():
     if len(sys.argv) < 2:
-        exit(1)
+        sys.exit(1)
 
     REF_IDX = -1
     ALT_IDX = -1

--- a/scripts/update_mutation_locus.py
+++ b/scripts/update_mutation_locus.py
@@ -106,8 +106,8 @@ def set_gene_locus(mut):
         symbol = str(mut).replace('inter-', 'intergenic ')\
                          .replace('promoter_', 'promoter ')\
                          .split('_')[-1].lower()
-        is_a = str(a.gene_symbol).lower() == symbol or str(a.name).lower() == symbol
-        is_b = str(b.gene_symbol).lower() == symbol or str(b.name).lower() == symbol
+        is_a = symbol in (str(a.gene_symbol).lower(), str(a.name).lower())
+        is_b = symbol in (str(b.gene_symbol).lower(), str(b.name).lower())
         if is_a and not is_b:
             print("A: Moving mutation from {} to {}".format(mut.gene_locus, a))
             mut.gene_locus = a

--- a/scripts/update_mutation_names.py
+++ b/scripts/update_mutation_names.py
@@ -48,7 +48,7 @@ class Command(object):
                 for m_field, original, data in changes:
                     self.debug(f"  > {m_field} changed '{original}' to '{data}'")
                 if changes:
-                    self.debug(f" ++ Saving mutation changes")
+                    self.debug(" ++ Saving mutation changes")
                     mutation.save()
             except ValueError:
                 unmatched.append(mutation.name)


### PR DESCRIPTION
* Use `sys.exit()` calls
* Use negative index `-1` to get the last element of sequence
* Remove unnecessary use of comprehension
* Remove unnecessary f-string
* Fix incorrect f-string syntax
* Replace multiple `==` checks with `in`

To check if a variable is equal to one of many values, combine the
values into a tuple and check if the variable is contained in it instead
of checking for equality against each of the values. This is faster,
less verbose, and more readable.

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>