### PR TITLE
(bugfix): update `plt.close` to be a function call

### DIFF
--- a/R/Neural_Network/program/Helper.py
+++ b/R/Neural_Network/program/Helper.py
@@ -50,7 +50,7 @@ def pics(auc, name, rep):
         plt.legend(loc="lower right")
         #plt.show()
         pdf.savefig()
-        plt.close
+        plt.close()
 
 ########################################################################
 # Marginal Effets                                                      #


### PR DESCRIPTION
Updated to be `matplotlib.pyplot.close(fig=None)`

[Relevant documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.close.html#matplotlib-pyplot-close)